### PR TITLE
fix: remove homepage from package config

### DIFF
--- a/wpe-cli/Cargo.toml
+++ b/wpe-cli/Cargo.toml
@@ -4,7 +4,6 @@ version = "0.0.19"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 description = "A CLI tool for the wpengine API."
-homepage = "https://github.com/thesandybridge/wpengine-cli"
 repository = "https://github.com/thesandybridge/wpengine-cli"
 readme = "../README.md"
 keywords = ["cli", "search", "demo"]


### PR DESCRIPTION
Removed homepage field from package config following the [manifest format recommandations](https://doc.rust-lang.org/cargo/reference/manifest.html#the-homepage-field):

> Do not make `homepage` redundant with either the `documentation` or `repository` values.